### PR TITLE
Switch from BrowserRouter to HashRouter, Plus Minor Optimizations

### DIFF
--- a/frontend/ofs-delivery/package-lock.json
+++ b/frontend/ofs-delivery/package-lock.json
@@ -353,6 +353,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -3929,11 +3938,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3946,15 +3957,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4057,7 +4071,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4067,6 +4082,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4079,17 +4095,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4106,6 +4125,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4178,7 +4198,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4188,6 +4209,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4293,6 +4315,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/frontend/ofs-delivery/src/App.js
+++ b/frontend/ofs-delivery/src/App.js
@@ -14,3 +14,5 @@ const App = ()=> (
     </div>
   </Router>
 );
+
+export default App;

--- a/frontend/ofs-delivery/src/App.js
+++ b/frontend/ofs-delivery/src/App.js
@@ -1,21 +1,16 @@
 import React, { Component } from 'react';
-import { Route } from "react-router-dom";
-
-import SignIn from './components/sign_in';
+import { HashRouter as Router, Route } from "react-router-dom";
 
 import './css/bootstrap.min.css'
 import './css/shards.min.css'
 import './css/App.css'
 
+import SignIn from './components/sign_in';
 
-class App extends Component {
-  render() {
-    return (
-      <div className="App">
-        <Route path="/" component={SignIn} />
-      </div>
-    );
-  }
-}
-
-export default App;
+const App = ()=> (
+  <Router>
+    <div className="App">
+      <Route path="/" component={SignIn} />
+    </div>
+  </Router>
+);

--- a/frontend/ofs-delivery/src/index.js
+++ b/frontend/ofs-delivery/src/index.js
@@ -1,11 +1,6 @@
 import React from 'react';
-import ReactDOM, { render }  from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
+import { render }  from 'react-dom';
 import './css/index.css';
 import App from './App';
 
-ReactDOM.render(
-                <BrowserRouter>
-                  <App/>
-                </BrowserRouter>, 
-        document.getElementById('root'));
+render(<App/>,document.getElementById('root'));


### PR DESCRIPTION
-  [x] Remove useless default import from `ReactDOM`
-  [x] Change from class to function component since `state` is not used

HashRouter is better than BrowserRouter since it prevents a webpage from 404 not found error since the routes are created dynamically. Suppose we have a link `OFS/Cart` with BrowserRouter, the link will be `OFS/#/Cart`.

See more [here](https://medium.com/@djoepramono/react-router-4-gotchas-2ecd1282de65).